### PR TITLE
补充主键ID为Long类型的查询和删除方法（BaseService、BaseServiceImpl和BaseServiceMock）

### DIFF
--- a/zheng-common/src/main/java/com/zheng/common/base/BaseService.java
+++ b/zheng-common/src/main/java/com/zheng/common/base/BaseService.java
@@ -15,6 +15,8 @@ public interface BaseService<Record, Example> {
 	int deleteByExample(Example example);
 
 	int deleteByPrimaryKey(Integer id);
+	
+	int deleteByPrimaryKey(Long id);
 
 	int insert(Record record);
 

--- a/zheng-common/src/main/java/com/zheng/common/base/BaseService.java
+++ b/zheng-common/src/main/java/com/zheng/common/base/BaseService.java
@@ -39,6 +39,8 @@ public interface BaseService<Record, Example> {
 	Record selectFirstByExampleWithBLOBs(Example example);
 
 	Record selectByPrimaryKey(Integer id);
+	
+	Record selectByPrimaryKey(Long id);
 
 	int updateByExampleSelective(@Param("record") Record record, @Param("example") Example example);
 

--- a/zheng-common/src/main/java/com/zheng/common/base/BaseServiceImpl.java
+++ b/zheng-common/src/main/java/com/zheng/common/base/BaseServiceImpl.java
@@ -75,6 +75,24 @@ public abstract class BaseServiceImpl<Mapper, Record, Example> implements BaseSe
 	}
 
 	@Override
+	public int deleteByPrimaryKey(Long id) {
+		try {
+			DynamicDataSource.setDataSource(DataSourceEnum.MASTER.getName());
+			Method deleteByPrimaryKey = mapper.getClass().getDeclaredMethod("deleteByPrimaryKey", id.getClass());
+			Object result = deleteByPrimaryKey.invoke(mapper, id);
+			return Integer.parseInt(String.valueOf(result));
+		} catch (IllegalAccessException e) {
+			e.printStackTrace();
+		} catch (InvocationTargetException e) {
+			e.printStackTrace();
+		} catch (NoSuchMethodException e) {
+			e.printStackTrace();
+		}
+		DynamicDataSource.clearDataSource();
+		return 0;
+	}
+
+	@Override
 	public int insert(Record record) {
 		try {
 			DynamicDataSource.setDataSource(DataSourceEnum.MASTER.getName());
@@ -279,6 +297,25 @@ public abstract class BaseServiceImpl<Mapper, Record, Example> implements BaseSe
 		DynamicDataSource.clearDataSource();
 		return null;
 	}
+
+	@Override
+	public Record selectByPrimaryKey(Long id) {
+		try {
+			DynamicDataSource.setDataSource(DataSourceEnum.SLAVE.getName());
+			Method selectByPrimaryKey = mapper.getClass().getDeclaredMethod("selectByPrimaryKey", id.getClass());
+			Object result = selectByPrimaryKey.invoke(mapper, id);
+			return (Record) result;
+		} catch (IllegalAccessException e) {
+			e.printStackTrace();
+		} catch (InvocationTargetException e) {
+			e.printStackTrace();
+		} catch (NoSuchMethodException e) {
+			e.printStackTrace();
+		}
+		DynamicDataSource.clearDataSource();
+		return null;
+	}
+
 
 	@Override
 	public int updateByExampleSelective(@Param("record") Record record, @Param("example") Example example) {

--- a/zheng-common/src/main/java/com/zheng/common/base/BaseServiceMock.java
+++ b/zheng-common/src/main/java/com/zheng/common/base/BaseServiceMock.java
@@ -26,6 +26,11 @@ public abstract class BaseServiceMock<Mapper, Record, Example> implements BaseSe
 	}
 
 	@Override
+	public int deleteByPrimaryKey(Long id) {
+		return -1;
+	}
+	
+	@Override
 	public int insert(Record record) {
 		return -1;
 	}
@@ -77,6 +82,11 @@ public abstract class BaseServiceMock<Mapper, Record, Example> implements BaseSe
 
 	@Override
 	public Record selectByPrimaryKey(Integer id) {
+		return null;
+	}
+	
+	@Override
+	public Record selectByPrimaryKey(Long id) {
 		return null;
 	}
 


### PR DESCRIPTION
新增 selectByPrimaryKey(Long id) 和 deleteByPrimaryKey(Long id) 方法