### PR TITLE
修复ehcache 依赖冲突

### DIFF
--- a/zheng-common/pom.xml
+++ b/zheng-common/pom.xml
@@ -156,6 +156,12 @@
             <groupId>org.mybatis</groupId>
             <artifactId>mybatis-ehcache</artifactId>
             <version>${mybatis-ehcache.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.sf.ehcache</groupId>
+                    <artifactId>ehcache-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- mysql -->
         <dependency>


### PR DESCRIPTION
编译好的war包部署到tomcat时报错Element <defaultCache> does not allow nested <persistence> elements， 经过反复检查，发现是ehcache 依赖冲突造成的， `排除mybatis-ehcache的ehcache依赖后，war恢复正常，可以顺利的部署到Tomcat中，也可以使用jetty:run-exploded运行

报错日志如下：
---------
`
 org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'org.springframework.cache.interceptor.CacheInterceptor#0': Cannot resolve reference to bean 'cacheManager' while setting bean property 'cacheManager'; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'cacheManager' defined in file [/home/donaldjohn/installed_software/apache-tomcat-8.5.15/webapps/zheng-upms-server/WEB-INF/classes/applicationContext-ehcache.xml]: Cannot resolve reference to bean 'cacheManagerFactory' while setting bean property 'cacheManager'; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'cacheManagerFactory' defined in file [/home/donaldjohn/installed_software/apache-tomcat-8.5.15/webapps/zheng-upms-server/WEB-INF/classes/applicationContext-ehcache.xml]: Invocation of init method failed; nested exception is net.sf.ehcache.CacheException: Error configuring from input stream. Initial cause was null:12: Element <defaultCache> does not allow nested <persistence> elements.
`